### PR TITLE
genre-and-address

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,2 @@
+class Address < ApplicationRecord
+end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,2 @@
+class Genre < ApplicationRecord
+end

--- a/db/migrate/20241016135350_create_genres.rb
+++ b/db/migrate/20241016135350_create_genres.rb
@@ -1,0 +1,9 @@
+class CreateGenres < ActiveRecord::Migration[6.1]
+  def change
+    create_table :genres do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241116063611_create_orders.rb
+++ b/db/migrate/20241116063611_create_orders.rb
@@ -2,13 +2,13 @@ class CreateOrders < ActiveRecord::Migration[6.1]
   def change
     create_table :orders do |t|
       t.references :customer, null: false, foreign_key: true
-      t.string :address null:false
-      t.string :post_code null:false
-      t.string :name null:false
-      t.interger :total_amount null:false
-      t.interger :postage null:false
-      t.integer :payment_method null:false
-      t.integer :is_order null:false 
+      t.string :address, null: false
+      t.string :post_code, null: false
+      t.string :name, null: false
+      t.integer :total_amount, null: false
+      t.integer :postage, null: false
+      t.integer :payment_method, null: false
+      t.integer :is_order, null: false      
       t.timestamps
     end
   end

--- a/db/migrate/20241116135737_create_addresses.rb
+++ b/db/migrate/20241116135737_create_addresses.rb
@@ -1,0 +1,11 @@
+class CreateAddresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :addresses do |t|
+      t.references :customer, null: false, foreign_key: true
+      t.string :address, null: false
+      t.string :post_code, null: false
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2024_11_16_135737) do
 
-ActiveRecord::Schema.define(version: 2024_11_16_071615) do
+  create_table "addresses", force: :cascade do |t|
+    t.integer "customer_id", null: false
+    t.string "address", null: false
+    t.string "post_code", null: false
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id"], name: "index_addresses_on_customer_id"
+  end
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -45,15 +54,38 @@ ActiveRecord::Schema.define(version: 2024_11_16_071615) do
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end
 
-  create_table "items", force: :cascade do |t|
+  create_table "genres", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "items", force: :cascade do |t|
+    t.integer "genre_id", null: false
+    t.string "name", null: false
+    t.integer "price", null: false
+    t.text "introduction", null: false
+    t.boolean "is_active", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["is_active"], name: "index_items_on_is_active"
   end
 
   create_table "orders", force: :cascade do |t|
+    t.integer "customer_id", null: false
+    t.string "address", null: false
+    t.string "post_code", null: false
+    t.string "name", null: false
+    t.integer "total_amount", null: false
+    t.integer "postage", null: false
+    t.integer "payment_method", null: false
+    t.integer "is_order", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["customer_id"], name: "index_orders_on_customer_id"
   end
 
+  add_foreign_key "addresses", "customers"
+  add_foreign_key "items", "genres"
+  add_foreign_key "orders", "customers"
 end
-

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/genres.yml
+++ b/test/fixtures/genres.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/genre_test.rb
+++ b/test/models/genre_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
ジャンルモデルと配送先モデルの追加。

0から作り直して、developからプルして続きを作成しました。

ジャンルのマイグレーションの名前を変更して、一番最初に読み込ますことで、注文モデルのエラーを解決させます